### PR TITLE
Added Necessary Empty Folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,14 +7,6 @@ __pycache__/
 Irrelevant
 
 # Personal Content
-Archive/Input/*
-Archive/Output/*
-Archive/JSON/*
-
-Stage/Input/*
-Stage/Output/*
-Stage/JSON_Output/*
-
 */config.py
 CTCoConfigs.py
 

--- a/.gitignore
+++ b/.gitignore
@@ -18,10 +18,6 @@ Stage/JSON_Output/*
 */config.py
 CTCoConfigs.py
 
-# Files
-TODO LIST.txt
-Handles.txt
-
 # Credentials / API Auth
 configs.py
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,8 @@ Irrelevant
 
 # Personal Content
 Archive/Input/*
-Archive/JSON/*
 Archive/Output/*
+Archive/JSON/*
 
 Stage/Input/*
 Stage/Output/*

--- a/Archive/Input/.gitignore
+++ b/Archive/Input/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory. This serves as a placeholder to allow the empty folder.
+*
+# Except this file
+!.gitignore

--- a/Archive/JSON/.gitignore
+++ b/Archive/JSON/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory. This serves as a placeholder to allow the empty folder.
+*
+# Except this file
+!.gitignore

--- a/Archive/Output/.gitignore
+++ b/Archive/Output/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory. This serves as a placeholder to allow the empty folder.
+*
+# Except this file
+!.gitignore

--- a/Archive/READM.md
+++ b/Archive/READM.md
@@ -1,3 +1,0 @@
-## Purpose
-
-To track all processed data: e.g. analyzed pictures, txt files converted to JSONS, JSONS uploaded to CA

--- a/Archive/README.md
+++ b/Archive/README.md
@@ -1,0 +1,6 @@
+## Purpose
+
+To store processed data:
+- Analyzed pictures (Input), 
+- Text files (Output) 
+- JSONS uploaded to CA (JSON)

--- a/Stage/Input/.gitignore
+++ b/Stage/Input/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory. This serves as a placeholder to allow the empty folder.
+*
+# Except this file
+!.gitignore

--- a/Stage/JSON/.gitignore
+++ b/Stage/JSON/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory. This serves as a placeholder to allow the empty folder.
+*
+# Except this file
+!.gitignore

--- a/Stage/Output/.gitignore
+++ b/Stage/Output/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory. This serves as a placeholder to allow the empty folder.
+*
+# Except this file
+!.gitignore

--- a/Stage/README.md
+++ b/Stage/README.md
@@ -1,3 +1,6 @@
 ## Purpose
 
-To hold items to be processed: e.g. photos to be scanned by AI, txt files to be converted to JSONS, JSONS to be uploaded
+To hold items to be processed:
+- Analyzed pictures (Input), 
+- Text files (Output) 
+- JSONS uploaded to CA (JSON)


### PR DESCRIPTION
This adds empty folders to the directories which hold material for processing, namely `Input`, `Output`, and `JSON` folders to `Archive/` and `Stage/`.  Previously, those locations didn't exist in this repo despite being targeted in scripts. Additionally, we improved the README.md files in  `Archive/` and `Stage/`.